### PR TITLE
Update trie.go

### DIFF
--- a/trie/trie.go
+++ b/trie/trie.go
@@ -81,7 +81,7 @@ func (t *Trie) Delete(key []byte) bool {
 		for i := len(key) - 1; i >= 0; i-- {
 			path[i].children[key[i]] = nil
 			path[i].length--
-			if path[i].value == nil && path[i].length > 0 {
+			if path[i].value != nil || path[i].length > 0 {
 				break
 			}
 		}


### PR DESCRIPTION
Bug fix for the Trie.Delete method: The for-loop that clears out empty leafs along the deleted key path needs to stop when it reaches a node that is not empty (value != nil) or not a leaf (length > 0).
